### PR TITLE
adjusting  CountryDropdownField::__construct to match 3.1 DropdownField

### DIFF
--- a/code/CountryDropdownField.php
+++ b/code/CountryDropdownField.php
@@ -12,11 +12,10 @@ class CountryDropdownField extends DropdownField {
 	
 	protected $defaultToVisitorCountry = true;
 	
-	function __construct($name, $title = null, $source = null, $value = "", $form=null) {
+	function __construct($name, $title=null, $source=array(), $value='', $form=null, $emptyString=null) {
 		if(!is_array($source)) $source = Geoip::getCountryDropDown();
 		if(!$value) $value = Geoip::visitor_country();
-
-		parent::__construct($name, ($title===null) ? $name : $title, $source, $value, $form);
+		parent::__construct($name, ($title===null) ? $name : $title, $source, $value, $form, $emptyString);
 	}
 	
 	function defaultToVisitorCountry($val) {


### PR DESCRIPTION
adjusting  CountryDropdownField::__construct to match 3.1 DropdownField - this is just a tiny change to match 3.1 and adds some deprecated notices by sending any potential value for $emptyString.

it might be an idea to branch this into 3.1, keeping master as it is... 